### PR TITLE
Add check for internet availability before starting daemon

### DIFF
--- a/bashbullet2
+++ b/bashbullet2
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# wait for internet connection to avoid freeze on https://github.com/Boteium/bashbullet2/blob/master/src/libbashbullet.cpp#L193
+while :
+do
+    pingtime=$(ping -w 1 8.8.8.8 2>/dev/null | grep "ttl")
+    if [ "$pingtime" = "" ]; then
+        pingtimetwo=$(ping -w 1 www.google.com 2>/dev/null | grep "ttl")
+        if [ "$pingtimetwo" != "" ]; then
+            break;
+        fi
+    else
+        break;
+    fi
+    sleep 1
+done
+
 # initialize yad systray icon
 PIPE="$HOME/.bashbullet2/.systray_pipe"
 if [ -e "$PIPE" ];then

--- a/bashbullet2
+++ b/bashbullet2
@@ -3,13 +3,8 @@
 # wait for internet connection to avoid freeze on https://github.com/Boteium/bashbullet2/blob/master/src/libbashbullet.cpp#L193
 while :
 do
-    pingtime=$(ping -w 1 8.8.8.8 2>/dev/null | grep "ttl")
-    if [ "$pingtime" = "" ]; then
-        pingtimetwo=$(ping -w 1 www.google.com 2>/dev/null | grep "ttl")
-        if [ "$pingtimetwo" != "" ]; then
-            break;
-        fi
-    else
+    pingtime=$(ping -w 1 "api.pushbullet.com" 2>/dev/null | grep "ttl")
+    if [ "$pingtime" ]; then
         break;
     fi
     sleep 1


### PR DESCRIPTION
Hello!
I tried to run bashbullet2 on user session startup, but it freezes on https://github.com/Boteium/bashbullet2/blob/master/src/libbashbullet.cpp#L193 error, because wifi was not connected immediately. After that I cannot receive anything on my laptop from pushbullet. So here is the simple fix: `while` cycle will ping google (by ip and by domain) and check the result. If no internet connection - it will wait and try again to ping it. When internet connection will be available, bashbullet2 initalization will start