### PR TITLE
Replace system call with in-house bash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+config_dir/lib/helper
+config_dir/lib/helper_upload
+libbashbullet

--- a/src/libbashbullet.cpp
+++ b/src/libbashbullet.cpp
@@ -35,7 +35,7 @@ void handler(Json::Value& M ){
 	if( loopcount++ == 6 ){
 		// update timestamp atleast every 3 minutes
 		string cmd="touch "+ftimestamp;
-		system( cmd.c_str() );
+		run_bash( cmd.c_str() );
 		loopcount=0;
 	}
         string type=M["type"].asString();
@@ -85,7 +85,7 @@ void handler(Json::Value& M ){
 			                        cmds="cat <<< '"+ PU[0] +"'|" + cmd + " \"" + type + "\" \"" + PU[1] + "\" \"" + PU[2] + "\" \"" + PU[3] + "\" \"" + PU[4] + "\" &";
 					else
 			                        cmds="cat <<< '"+ PU[0] +"'|" + cmd + " \"" + type + "\" \"" + PU[1] + "\" \"" + PU[2] + "\" \"" + PU[3] + "\" &";
-	        	                system( cmds.c_str() );
+	                                run_bash( cmds.c_str() );
 					if(systray) update_icon(traypipe);
 				}
 			}
@@ -98,7 +98,7 @@ void handler(Json::Value& M ){
 			cout << "decrypting message" << endl;
 			if( key == "" ){
 				string cmds="echo |" +pdir + "handler/mirror.sh \"Bashbullet\" \"ERROR\" \"End to End encryption is on, but decryption key is missing\"";
-				system( cmds.c_str());
+				run_bash( cmds.c_str());
 				type = "dismissal";
 			}else{
 				string dec = pushbullet_decrypt(key, M["push"]["ciphertext"].asString() );
@@ -125,18 +125,18 @@ void handler(Json::Value& M ){
 			for(auto& s:PU)	sanitize(s);
 			string cmd=pdir+"handler/mirror.sh";
 			string cmds = "cat <<< '"+ PU[0] +"'|" + cmd + " \"" + PU[1] + "\" \"" + PU[2] + "\" \"" + PU[3] + "\" \"" + PU[4] + "\" &";
-			system( cmds.c_str() );
+			run_bash( cmds.c_str() );
 
 			cout << endl << "mirror: " << PU[1] << ':' << PU[2] << " :: " << PU[3] << endl;
 		}else if( type == "clip" ){
 			// untested, this is now payed function
 			string body = M["push"][ "body" ].asString();
 			string cmd="cat <<< '" + sanitize(body) + "'|" + pdir + "handler/clip.sh";
-			system( cmd.c_str() );
+			run_bash( cmd.c_str() );
 		}else if( type == "sms_changed" && enable_sms_alert ){
 			string from= iden2devname[ M["push"][ "source_device_iden" ].asString() ];
 			string cmd="echo |" +pdir + "handler/mirror.sh \"" + sanitize(from) + "\" \"SMS Received/Sent\"";
-			system( cmd.c_str());
+			run_bash( cmd.c_str());
 		}
         }
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -96,3 +96,7 @@ void save_devices( map<string,string>& iden2device, string pdir, vector<string> 
 
 	os.close();
 }
+
+void run_bash(const char *command) {
+    execl("/bin/bash", "bash", "-c", command, (char *) NULL);
+}

--- a/src/misc.h
+++ b/src/misc.h
@@ -15,4 +15,5 @@ string sanitize(string& in);
 Json::Value file_json(string);
 Json::Value str_json(string);
 
+void run_bash(const char *command);
 void save_devices( map<string,string>& , string, vector<string>);


### PR DESCRIPTION
C++ "system()" function uses the OS's non-interactive shell to execute the command.
In a lot of places, this is "sh", and not bash (even though the .sh scripts contain the
"#!/bin/bash" shebang).

The problem with this is that sh doesn't support a lot of bash syntax. Case in point,
if you run libbashbullet as is on a Debian 9.0 system, no script will run because of
"Syntax error: redirection unexpected" error.

Replace this by forcefully executing "bin/bash" using execl, and scripts will now work.

This could also become configurable in the config.json